### PR TITLE
feat: Adds `transpose_into_fallible_async` for iterator adaptors

### DIFF
--- a/src/adaptors/futures_core.rs
+++ b/src/adaptors/futures_core.rs
@@ -13,6 +13,17 @@ pub trait FuturesCoreStreamExt {
     fn into_fallible_async<T>(self) -> FuturesCoreStreamAdaptor<Self>
     where
         Self: Stream<Item = T> + Sized;
+
+    /// Change a [`Stream<Item = Result<T, E>>`][`futures_core::Stream`] to a
+    /// [`FallibleAsyncIterator<Item = T, Error = E>`][`FallibleAsyncIterator`].
+    fn transpose_into_fallible_async<T, E>(self) -> crate::Transpose<FuturesCoreStreamAdaptor<Self>>
+    where
+        Self: Stream<Item = Result<T, E>> + Sized,
+    {
+        crate::Transpose {
+            iter: self.into_fallible_async(),
+        }
+    }
 }
 
 impl<S: Stream> FuturesCoreStreamExt for S {

--- a/src/adaptors/std_async_iterator.rs
+++ b/src/adaptors/std_async_iterator.rs
@@ -11,13 +11,24 @@ use crate::FallibleAsyncIterator;
 pub trait AsyncIteratorExt {
     fn into_fallible_async<T>(self) -> AsyncIteratorAdaptor<Self>
     where
-        Self: Iterator<Item = T> + Sized;
+        Self: AsyncIterator<Item = T> + Sized;
+
+    /// Change an [`AsyncIterator<Item = Result<T, E>>`][`std::async_iter::AsyncIterator`] to a
+    /// [`FallibleAsyncIterator<Item = T, Error = E>`][`FallibleAsyncIterator`].
+    fn transpose_into_fallible_async<T, E>(self) -> crate::Transpose<AsyncIteratorAdaptor<Self>>
+    where
+        Self: AsyncIterator<Item = Result<T, E>> + Sized,
+    {
+        crate::Transpose {
+            iter: self.into_fallible_async(),
+        }
+    }
 }
 
 impl<I: AsyncIterator> AsyncIteratorExt for I {
     fn into_fallible_async<T>(self) -> AsyncIteratorAdaptor<Self>
     where
-        Self: Iterator<Item = T> + Sized,
+        Self: AsyncIterator<Item = T> + Sized,
     {
         AsyncIteratorAdaptor { iter: self }
     }

--- a/src/adaptors/std_iterator.rs
+++ b/src/adaptors/std_iterator.rs
@@ -6,11 +6,22 @@ use core::{
 
 use crate::FallibleAsyncIterator;
 
-/// Extension methods for `std::iter::Iterator`.
+/// Extension methods for [`std::iter::Iterator`].
 pub trait IteratorExt {
     fn into_fallible_async<T>(self) -> IteratorAdaptor<Self>
     where
         Self: Iterator<Item = T> + Sized;
+
+    /// Change an [`Iterator<Item = Result<T, E>>`][`std::iter::Iterator`] to a
+    /// [`FallibleAsyncIterator<Item = T, Error = E>`][`FallibleAsyncIterator`].
+    fn transpose_into_fallible_async<T, E>(self) -> crate::Transpose<IteratorAdaptor<Self>>
+    where
+        Self: Iterator<Item = Result<T, E>> + Sized,
+    {
+        crate::Transpose {
+            iter: self.into_fallible_async(),
+        }
+    }
 }
 
 impl<I: Iterator> IteratorExt for I {
@@ -22,7 +33,7 @@ impl<I: Iterator> IteratorExt for I {
     }
 }
 
-/// Adapts a `std::iter::Iterator` into a [`FallibleAsyncIterator`].
+/// Adapts a [`std::iter::Iterator`] into a [`FallibleAsyncIterator`].
 pub struct IteratorAdaptor<I> {
     iter: I,
 }


### PR DESCRIPTION
These functions change a source which iterates over `Result<T, E>`s into a `FallibleAsyncIterator` which yields `T`s and errors with `E`s.